### PR TITLE
Use the systems default RNG

### DIFF
--- a/src/one_time/util.clj
+++ b/src/one_time/util.clj
@@ -5,5 +5,5 @@
   "Generate a random byte array."
   [size]
   (let [bytes (byte-array size)]
-    (.nextBytes (SecureRandom/getInstance "SHA1PRNG") bytes) ; mutating api
+    (-> (SecureRandom.) (.nextBytes bytes)) ; mutating api
     bytes))


### PR DESCRIPTION
Using the systems default RNG for greater portability and feeling more secure.

https://stackoverflow.com/questions/27622625/securerandom-with-nativeprng-vs-sha1prng