### PR TITLE
Use default rng instead of hardcoded sha1prng

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,11 @@ language: clojure
 lein: lein
 script: lein all test
 jdk:
-  - openjdk8
   - openjdk9
-  - openjdk10
-  - openjdk11
-  - oraclejdk8
-  - oraclejdk9
+  - openjdk13
+  - openjdk-ea
   - oraclejdk11
+  - oraclejdk13
+  - oraclejdk-ea
 after_script:
   - lein cloverage -o cov --coveralls && curl -F 'json_file=@cov/coveralls.json' 'https://coveralls.io/api/v1/jobs'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Changed
+- Use system default RNG instead of hardcoded SHA1PRNG. (Available implementations listed at https://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html#SecureRandomImp)
 
 ## [0.5.0] - 2019-02-22
 ### Added

--- a/src/one_time/util.clj
+++ b/src/one_time/util.clj
@@ -5,5 +5,5 @@
   "Generate a random byte array."
   [size]
   (let [bytes (byte-array size)]
-    (.nextBytes (SecureRandom/getInstance "SHA1PRNG") bytes) ; mutating api
+    (-> (SecureRandom.) (.nextBytes bytes)) ; mutating api
     bytes))


### PR DESCRIPTION
Available implementations listed at
https://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html#SecureRandomImp