### PR TITLE
Use constant-time comparison for TOTP tokens

### DIFF
--- a/src/one_time/core.clj
+++ b/src/one_time/core.clj
@@ -4,6 +4,16 @@
             [one-time.totp  :as totp]
             [one-time.hotp  :as hotp]))
 
+(defn ^:private safe=
+  "Constant-time comparison (for numbers with equal base 10 length) for numeric
+  types, via bytewise string equality of the decimal representation."
+  [x y]
+  (let [x' (.getBytes (str x))
+        y' (.getBytes (str y))]
+    (and
+      (= (count x') (count y'))
+      (zero? (reduce bit-or (map bit-xor x' y'))))))
+
 (defn generate-secret-key
   "Generate a secret key for use in TOTP/HOTP."
   []
@@ -22,9 +32,9 @@
 (defn is-valid-totp-token?
   "Checks if the presented totp token is valid against a secret and options"
   ([token secret]
-   (== token (get-totp-token secret)))
+   (safe= token (get-totp-token secret)))
   ([token secret options]
-   (== token (get-totp-token secret options))))
+   (safe= token (get-totp-token secret options))))
 
 (defn get-hotp-token
   "Gets the HOTP token for the secret and counter provided"
@@ -34,4 +44,4 @@
 (defn is-valid-hotp-token?
   "Checks if the presented hotp token is valid against a secret and counter"
   [token secret counter]
-  (== token (get-hotp-token secret counter)))
+  (safe= token (get-hotp-token secret counter)))

--- a/test/one_time/core_test.clj
+++ b/test/one_time/core_test.clj
@@ -1,7 +1,23 @@
 (ns one-time.core-test
-  (:require [clojure.test :refer [deftest testing is]]
+  (:require [clojure.test :refer [deftest testing is are]]
             [one-time.test-helper :as th]
             [one-time.core :as ot]))
+
+(deftest safe=-test
+  (are [x] (#'ot/safe= x x)
+    0
+    1
+    111
+    123
+    1111111111111111)
+
+  (is (not (#'ot/safe= 12345 12945)))
+  (is (not (#'ot/safe= 10 0)))
+  (is (not (#'ot/safe= 0 10)))
+
+  (testing "safe= on non-equal numbers with equal prefixes"
+    (is (not (#'ot/safe= 11111 11)))
+    (is (not (#'ot/safe= 11 11111)))))
 
 (deftest generate-secret-key-test
   (testing "Secret Key type and length test"


### PR DESCRIPTION
FWIW, upon review, it's not clear to me this is actually exploitable in most real scenarios. It's comparing numeric types, so technically you may need to worry about the numeric type the caller gives you. In practice, this will either be something like an Integer or a BigInteger/BigInt. All of these have limbs larger than the space for HTOP/TOTP codes, so it's likely there won't be a real exploitable timing differential. But this makes that a bit more ironclad.