### PR TITLE
Revert "Use safer comparison for TOTP tokens"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,17 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
-### Added
-- Add (constant) time safe comparision of tokens
+### Notes
+- An intermediate unreleased version had an attempt at (constant) time safe
+  comparision of tokens introduced in #11. This change introduced a subtle
+  vulnerability (see #12 for details). The following commits in the `main`
+  branch are vulnerable:
+
+  * d69435b4d91769a8f84ecd0e32ebda607fc9de85
+  * 60d161c525a1b750fff28d4adcc5c2cc7597cf4c
+  * 86a90eb55103fbebb878a8be2208433825bec0ed
+
+  We've searched GitHub to make sure nobody is using these.
 
 ## [0.7.0] - 2020-08-09
 ### Added

--- a/src/one_time/core.clj
+++ b/src/one_time/core.clj
@@ -4,16 +4,6 @@
             [one-time.totp  :as totp]
             [one-time.hotp  :as hotp]))
 
-(defn ^:private safe=
-  "Constant-time comparison (for numbers with equal base 10 length) for numeric
-  types, via bytewise string equality of the decimal representation."
-  [x y]
-  (let [x' (.getBytes (str x))
-        y' (.getBytes (str y))]
-    (and
-      (= (count x') (count y'))
-      (zero? (reduce bit-or (map bit-xor x' y'))))))
-
 (defn generate-secret-key
   "Generate a secret key for use in TOTP/HOTP."
   []
@@ -32,9 +22,9 @@
 (defn is-valid-totp-token?
   "Checks if the presented totp token is valid against a secret and options"
   ([token secret]
-   (safe= token (get-totp-token secret)))
+   (== token (get-totp-token secret)))
   ([token secret options]
-   (safe= token (get-totp-token secret options))))
+   (== token (get-totp-token secret options))))
 
 (defn get-hotp-token
   "Gets the HOTP token for the secret and counter provided"
@@ -44,4 +34,4 @@
 (defn is-valid-hotp-token?
   "Checks if the presented hotp token is valid against a secret and counter"
   [token secret counter]
-  (safe= token (get-hotp-token secret counter)))
+  (== token (get-hotp-token secret counter)))

--- a/test/one_time/core_test.clj
+++ b/test/one_time/core_test.clj
@@ -1,23 +1,7 @@
 (ns one-time.core-test
-  (:require [clojure.test :refer [deftest testing is are]]
+  (:require [clojure.test :refer [deftest testing is]]
             [one-time.test-helper :as th]
             [one-time.core :as ot]))
-
-(deftest safe=-test
-  (are [x] (#'ot/safe= x x)
-    0
-    1
-    111
-    123
-    1111111111111111)
-
-  (is (not (#'ot/safe= 12345 12945)))
-  (is (not (#'ot/safe= 10 0)))
-  (is (not (#'ot/safe= 0 10)))
-
-  (testing "safe= on non-equal numbers with equal prefixes"
-    (is (not (#'ot/safe= 11111 11)))
-    (is (not (#'ot/safe= 11 11111)))))
 
 (deftest generate-secret-key-test
   (testing "Secret Key type and length test"


### PR DESCRIPTION
This reverts commit d69435b4d91769a8f84ecd0e32ebda607fc9de85 and introduces a CHANGELOG entry about why.

A summary of the bug is as follows: the previous version did introduce a timing differential on the length of the TOTP code. This was discussed in the PR (#11), but an underlying issue was missed in that discussion. The rationale for the short-circuit branch on the length of the TOTP code differential didn't matter is twofold:

1. without it, you have a truncation vulnerability; e.g. the attacker submits `1` and any TOTP code starting with `1` is accepted
2. the length of the TOTP code is public anyway.

That's true, but misses another point. By random chance, the legitimate TOTP code will sometimes be a number small enough that it doesn't require all (usually 6) digits to represent. 10% of the time the first digit will be zero, 1% of the time the first two will be, and so on. The string conversion will result in a shorter code string, because it doesn't know to pad with zeroes. If the attacker submits full-length TOTP codes, the fast short-circuit tells them the real code is shorter. The attacker can then submit shorter and shorter codes until the timing differential tells them they've found the right length. Finally, they only need to be patient enough to hit a 30-second window where the remaining nonzero codes are enumerable.

Let's put some numbers on how likely that is. The probability of any particular code having N prefix zeroes is 10^(-N). The probability of seeing any such code over M codes is 1-(1-10^(-N))^M. A day is 86400 seconds; given the standard
refresh of a TOTP of 30s, that’s 2880 values per day. For N=3 prefix zeroes and M=2880 (the probability of seeing at least one code with 3 prefix zeroes over 24 hours) is about 94%. For N=4, M=2880, 25%. For N=5, M=2880, 3%.

There may be a way to rehabilitate this approach but in the mean while reverting to the probably-not-exploitable-but-dependent-on-the-caller version is.

Thanks to @cursork and @sw1nn for raising this! Sorry it took so long to see it.